### PR TITLE
Add aggregation alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,9 @@
     "require": {
         "php": ">=5.4.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "3.7.*"
+    },
     "autoload": {
         "psr-0": {
             "LinguaLeo\\": "src/"

--- a/src/LinguaLeo/DataQuery/Criteria.php
+++ b/src/LinguaLeo/DataQuery/Criteria.php
@@ -83,9 +83,9 @@ class Criteria
         return $this;
     }
 
-    public function aggregate($func, $field = null)
+    public function aggregate($func, $field = null, $alias = null)
     {
-        $this->aggregations[] = [$func, $field];
+        $this->aggregations[] = [$func, $field, $alias];
         return $this;
     }
 

--- a/tests/LinguaLeo/DataQuery/CriteriaTest.php
+++ b/tests/LinguaLeo/DataQuery/CriteriaTest.php
@@ -28,6 +28,7 @@ namespace LinguaLeo\DataQuery;
 
 class CriteriaTest extends \PHPUnit_Framework_TestCase
 {
+    /** @var Criteria */
     protected $criteria;
 
     public function setUp()
@@ -83,7 +84,11 @@ class CriteriaTest extends \PHPUnit_Framework_TestCase
     {
         $this->criteria->aggregate('count');
         $this->criteria->aggregate('sum', 'a');
-        $this->assertSame([['count', null], ['sum', 'a']], $this->criteria->aggregations);
+        $this->criteria->aggregate('sum', 'a', 'sum_alias');
+        $this->assertSame(
+            [['count', null, null], ['sum', 'a', null], ['sum', 'a', 'sum_alias']],
+            $this->criteria->aggregations
+        );
     }
 
     public function testWrite()


### PR DESCRIPTION
Добавил опциональный алиас для аггрегирующих колонок, чтобы потом при разборе результата можно было читать их из массива по алиасу, а не заниматься самом еще раз конкатенацией "function(fields)".

В php-dataquery-mysql будет соответствующая поддержка при формировании SQL.
